### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "academiasd"
 description = "Official set of custom nodes of AcademiaSD."
-version = "1.0.0"
+version = "1.2.6"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)
@@ -28,7 +28,7 @@ Documentation = "https://github.com/AcademiaSD/comfyui_AcademiaSD/wiki"
 "Bug Tracker" = "https://github.com/AcademiaSD/comfyui_AcademiaSD/issues"
 
 [tool.comfy]
-PublisherId = ""
+PublisherId = "@academia-sd"
 DisplayName = "comfyui_AcademiaSD"
 Icon = ""
 includes = [] 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "academiasd"
+description = "Official set of custom nodes of AcademiaSD."
+version = "1.0.0"
+license = {file = "LICENSE"} 
+# classifiers = [
+#     # For OS-independent nodes (works on all operating systems)
+#     "Operating System :: OS Independent",
+#
+#     # OR for OS-specific nodes, specify the supported systems:
+#     "Operating System :: Microsoft :: Windows",  # Windows specific
+#     "Operating System :: POSIX :: Linux",  # Linux specific
+#     "Operating System :: MacOS",  # macOS specific
+#
+#     # GPU Accelerator support. Pick the ones that are supported by your extension.
+#     "Environment :: GPU :: NVIDIA CUDA",    # NVIDIA CUDA support
+#     "Environment :: GPU :: AMD ROCm",       # AMD ROCm support
+#     "Environment :: GPU :: Intel Arc",      # Intel Arc support
+#     "Environment :: NPU :: Huawei Ascend",  # Huawei Ascend support
+#     "Environment :: GPU :: Apple Metal",    # Apple Metal support
+# ]
+
+
+[project.urls]
+Repository = "https://github.com/AcademiaSD/comfyui_AcademiaSD"
+#  Used by Comfy Registry https://registry.comfy.org
+Documentation = "https://github.com/AcademiaSD/comfyui_AcademiaSD/wiki"
+"Bug Tracker" = "https://github.com/AcademiaSD/comfyui_AcademiaSD/issues"
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "comfyui_AcademiaSD"
+Icon = ""
+includes = [] 
+# "requires-comfyui" = ">=1.0.0"  # ComfyUI version compatibility
+


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. 

The registry is already integrated with ComfyUI-Manager, and we want it to be the default place users install nodes from eventually. We do a security-scan of every node to improve safety. Feel free to read up more on the registry [here](https://docs.comfy.org/registry/overview#introduction)

- The documentation scaffolding? You can just add the example markdown [here](https://docs.comfy.org/custom-nodes/help_page#setup) into web/docs/MyNode.md

Action Required:

- [x] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [x] Add the publisher id into the pyproject.toml file.
- [x] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Otherwise, if you have any questions, please message me on discord at robinken or join our [server](https://discord.com/invite/comfyorg)!